### PR TITLE
Add selinux compatibility

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -104,6 +104,7 @@ suites:
   - name: default
     run_list:
       - recipe[squid::default]
+      - recipe[squid::selinux]
     attributes:
       squid:
         cache_size: 10

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -28,6 +28,7 @@ suites:
   - name: default
     run_list:
       - recipe[squid::default]
+      - recipe[squid::selinux]
     attributes:
       squid:
         cache_size: 10

--- a/metadata.rb
+++ b/metadata.rb
@@ -16,3 +16,5 @@ source_url 'https://github.com/chef-cookbooks/squid'
 issues_url 'https://github.com/chef-cookbooks/squid/issues'
 
 chef_version '>= 12.1'
+
+depends 'selinux_policy', '1.0.0'

--- a/recipes/selinux.rb
+++ b/recipes/selinux.rb
@@ -1,0 +1,36 @@
+#
+# Cookbook Name:: squid
+# Recipe:: selinux
+#
+# Copyright 2013-2016, Chef Software, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_recipe 'selinux_policy::install'
+
+selinux_policy_module 'squid' do
+  content <<-eos
+    module squid 1.0;
+
+    require {
+      type user_tmpfs_t;
+      type squid_t;
+      class file unlink;
+    }
+
+    #============= squid_t ==============
+    allow squid_t user_tmpfs_t:file unlink;
+  eos
+  action :deploy
+end


### PR DESCRIPTION
### Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


Squid will fail to start in an environment where selinux is enforcing.
This change adds a module that allows squid to start correctly.