### PR TITLE
Squid as a transparent proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,37 @@ The following two data bags are only required if you are using LDAP Authenticati
 }
 ```
 
+### Squid as a transparent proxy
+
+#### Generating certificates
+```
+certtool --generate-privkey --outfile ca-key.pem
+certtool --generate-self-signed --load-privkey ca-key.pem --outfile myCA.pem
+```
+
+To get the content in a form that chef will accept in it's databags run the following:
+
+```
+chef exec ruby -e 'p ARGF.read' myCA.pem
+```
+
+#### Configuring cookbook
+```node['squid']['enable_ssl_bump'] = true```
+
+Create a databag named ```squid_ssl```
+
+The content of this databag should look like:
+
+```javascript
+{
+  "id": "proxy",
+  "content": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCzs54vZK7GjgOI\noPEGsGVeeSSR3m1JKIKjSZcPiH/CqOJF2PorLRI78lY0GsT4iO+HTc8PEKDGfmA0\ntztT8Vfimc17o5UxEzOknPUbrrG5kHlf5bzZRF22B3qdkeZ/+0Yno0gqXWaDf5qA\nK9pXuWODz0Ft+PYkppTIVIaQRd45T+WnvWb4VXO3nKge0X+RWtGXwoEzHBjO5ViK\nV2x2E4AQMMesa/kxcGIeGsJ1nPQWmoi/sxk/bAgf6Rcc7OzTlXSFn4g53CFnGRJE\nQEHWma29QLJPeR79EJj351Z+hooTIYQ6pQmqNAzrwqttxhCyouceBb2Wix46N+qp\nksl9gu9zAgMBAAECggEAKJNwLmdfh3ndlmYwxj/iQ7i65y0AJDq/dLtTHrDFmGCl\n5vudUU52BY8so8s/mpbg7v5EuLQaeXdjpcOR49xk6cesvDQtpc0eJhdCySNjAfF7\nVon7YFuthUKfDyE4mMFWD/EwhFBeq2aOrk44mQJFVCfiMEC8432xrqJXWBBOo0Xj\n8zKY17lN0Ud9ppouu7mpNw7ObpTV1s7VbS2MDAi+jk0CrXe91XxX2WGhPezPLG9J\nMxxEtnyReRwOrgNeoUN6rSuTdLqkOqGK39hvyWeqPCp8s+iE6t4oYHHH3A4F8PoY\n7vJ9X8gvST0yFVznPafbhSIiAhKW96a2OZsv5Ymr0QKBgQDpSo2vrHk7JNnMo3xK\n4eL9EmXnrV5w1DZLgHcIZp8hDO7ARzqw8w4A+O7N2QM/DIUmH2ND/The5/WkE9BA\nyI7Vc6owtwFKiJmOJ59TvrQeS+4KLhMpNs8VjqwSqPbIFK3iQj6LxEZoeZQxTEi0\n7b22jdS4eShGip28iCDlI8qBxQKBgQDFMaaq53w3SHQydnUMcrR3ZuEfrKSiNRNi\nf6K2uatW1EeVGwn9UKZPMWTuAs5HcSWVg8+uLtaxhyglzw22yuB+d2YowyN7MZMt\nUBb0W8o7rkY4eMZful6ostskmAvL1mKTqamS/7857MIokhfeTXCJBDV2qoGVUgRM\nXWpkfl5X1wKBgQDeJVYCAJR4U0Dqcor6q1qAbbKICDiz6/+/qZavczj4Od5nTex/\nbxLYrjKH5awHr55ijOTzav7wsKTiFtPpvJD2hOt88+bQ2H6QNP6suh2988O6AeHR\nDxXmizMjma1VHQvvNfFlGgOJnKwWvXNGhlRur2PuPcCyW3CUhHP+fjRpmQKBgDuo\nSMb9n1vORLEbm0+3yBczfboqbehQ7FtpR93GECsFr95RPtVvN9FPnTxQhv2gIoG4\nTfVhYDx3KlM97+U0PXSlRLfiSXK0zdTwnPEyb91cXQwqpcFCTe71pUzN3wu9ATex\nJYc+bijlEtxZTnVHslsRdec/sFJvbLN5s31RqdMjAoGAdH7bsvs0WurflryDB3XD\nq00j5WIcHkZG4+E55QZiNsJKAbtLPACu4D/qCEX5bC/QXMF3Uo/lNfuIKYMLA7kF\n07bZ+egNV5tNViKQ40qHHg4JDgtJz8Y64aBYjacyYEQgPQBlIuOSB4WmBrbmg8m9\nQzZWHNDCarKfqS78V16/eb0=\n-----END PRIVATE KEY-----\n-----BEGIN CERTIFICATE-----\nMIIDVzCCAj+gAwIBAgIJAIj1wumabLf9MA0GCSqGSIb3DQEBCwUAMEIxCzAJBgNV\nBAYTAlhYMRUwEwYDVQQHDAxEZWZhdWx0IENpdHkxHDAaBgNVBAoME0RlZmF1bHQg\nQ29tcGFueSBMdGQwHhcNMTYwOTE5MTMwODMwWhcNMTcwOTE5MTMwODMwWjBCMQsw\nCQYDVQQGEwJYWDEVMBMGA1UEBwwMRGVmYXVsdCBDaXR5MRwwGgYDVQQKDBNEZWZh\ndWx0IENvbXBhbnkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA\ns7OeL2Suxo4DiKDxBrBlXnkkkd5tSSiCo0mXD4h/wqjiRdj6Ky0SO/JWNBrE+Ijv\nh03PDxCgxn5gNLc7U/FX4pnNe6OVMRMzpJz1G66xuZB5X+W82URdtgd6nZHmf/tG\nJ6NIKl1mg3+agCvaV7ljg89Bbfj2JKaUyFSGkEXeOU/lp71m+FVzt5yoHtF/kVrR\nl8KBMxwYzuVYildsdhOAEDDHrGv5MXBiHhrCdZz0FpqIv7MZP2wIH+kXHOzs05V0\nhZ+IOdwhZxkSREBB1pmtvUCyT3ke/RCY9+dWfoaKEyGEOqUJqjQM68KrbcYQsqLn\nHgW9loseOjfqqZLJfYLvcwIDAQABo1AwTjAdBgNVHQ4EFgQUV8MfuOCDKKayxUEI\nbj3waW5tY8wwHwYDVR0jBBgwFoAUV8MfuOCDKKayxUEIbj3waW5tY8wwDAYDVR0T\nBAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAOTiWkv6NMjEnIb0ehBtFSaKcmocr\nbouZnnIUThqBHTva1l85KD7CAUUBnWAIccwGreHkp6aGlxIrZStmI0+kP/XSNQgJ\nR08r5DX6CWdu1PtdhiF2pIvJmYvyez1itD9CgQNvxkockAYVgvp5KQEwGP+ugN5V\nlIdjUWn0Xa5kSZr1Vl5EPlRetqATSU/1AFWGu5JZUwkldPdM2jy3ANQZ1D/cR+Tm\nrbY0vkQXI7b9imYcgVKqKNHO5b2V/PSe8bSKLwGqk2QHZnHABWYzcgwcu7patJWu\n+Ev5lsJp01w8WFyaN0IsoWG/ysPIFeFdgQAN4aEG19DIDJnu/0etaWxRHw==\n-----END CERTIFICATE-----\n",
+  "whitelist": [
+    ".google.com"
+  ]
+}
+```
+
 ## License & Authors
 
 **Author:** Cookbook Engineering Team ([cookbooks@chef.io](mailto:cookbooks@chef.io))

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -29,6 +29,7 @@ default['squid']['hosts_databag_name'] = 'squid_hosts'
 default['squid']['urls_databag_name'] = 'squid_urls'
 
 default['squid']['package'] = 'squid'
+default['squid']['helper_package'] = 'squid-helpers'
 default['squid']['config_dir'] = '/etc/squid'
 default['squid']['config_file'] = '/etc/squid/squid.conf'
 default['squid']['log_dir'] = '/var/log/squid'
@@ -50,6 +51,10 @@ default['squid']['max_obj_size_unit'] = 'MB'
 default['squid']['enable_cache_dir'] = true
 default['squid']['logformats'] = {}
 default['squid']['access_log_option'] = 'squid'
+
+default['squid']['enable_ssl_bump'] = false
+default['squid']['ssl_databag_name'] = 'squid_ssl'
+default['squid']['ssl_port'] = 3130
 
 default['squid']['enable_ldap']       = false
 default['squid']['ldap_host']         = nil   # 'ldap.here.com'

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -69,6 +69,18 @@ module Opscode
         end
         acls
       end
+
+      def squid_load_ssl(databag_name)
+        ssl = {}
+        begin
+          data = data_bag_item(databag_name, 'proxy')
+          ssl['certificate'] = data['content']
+          ssl['whitelist'] = data['whitelist']
+        rescue
+          Chef::Log.info "no '#{databag_name}' data bag"
+        end
+        ssl
+      end
     end
   end
 end

--- a/templates/default/squid.conf.erb
+++ b/templates/default/squid.conf.erb
@@ -20,12 +20,6 @@ auth_param basic credentialsttl <%= node['squid']['ldap_authcredentialsttl'] %>
 acl localnet src <%= localnet %>
 <% end %>
 
-acl localnet src 10.0.0.0/8	# RFC1918 possible internal network
-acl localnet src 172.16.0.0/12	# RFC1918 possible internal network
-acl localnet src 192.168.0.0/16	# RFC1918 possible internal network
-acl localnet src fc00::/7       # RFC4193 local private network range
-acl localnet src fe80::/10      # RFC4291 link-local (directly-plugged) machine
-
 <% @ssl_ports.each do |port| %>
 acl SSL_ports port <%= port %>
 <% end %>
@@ -46,6 +40,30 @@ acl <%= url[0] %> <%= url[1] %> <%= url[2] %>
 http_access <%= acl[0] %> <%= acl[1] %> <%= acl[2] %>
 <% end %>
 
+<% if node['squid']['enable_ssl_bump'] %>
+http_port <%= node['squid']['port'] %> ssl-bump cert=<%= node['squid']['config_dir'] %>/ssl_cert/squid.pem generate-host-certificates=on dynamic_cert_mem_cache_size=4MB
+https_port <%= node['squid']['ssl_port'] %> ssl-bump intercept cert=<%= node['squid']['config_dir'] %>/ssl_cert/squid.pem generate-host-certificates=on dynamic_cert_mem_cache_size=4MB
+
+acl step1 at_step SslBump1
+acl step2 at_step SslBump2
+acl step3 at_step SslBump3
+
+acl allowed_https_sites ssl::server_name "<%= node['squid']['config_dir'] %>/whitelist.txt"
+
+ssl_bump peek step1 all                   # at step 1 we're peeking at client TLS-request in order to find the SNI
+ssl_bump peek step2 allowed_https_sites   # here we're peeking at server certificate
+ssl_bump splice step3 allowed_https_sites # here we're splicing connections which match the whitelist
+ssl_bump terminate all
+<% else %>
+<% if node['squid']['port'].kind_of?(Array) %>
+<% node['squid']['port'].each do |port| %>
+http_port <%= port %>
+<% end %>
+<% else %>
+http_port <%= node['squid']['port'] %>
+<% end %>
+<% end %>
+
 http_access allow manager localhost
 http_access deny manager
 http_access allow purge localhost
@@ -58,15 +76,8 @@ http_access deny all
 
 <%= "icp_access allow localnet" if !@localnets.empty? %>
 icp_access deny all
-<% if node['squid']['port'].kind_of?(Array) %>
-  <% node['squid']['port'].each do |port| %>
-http_port <%= port %>
-  <% end %>
-<% else %>
-http_port <%= node['squid']['port'] %>
-<% end %>
 
-hierarchy_stoplist cgi-bin ?
+<%= "hierarchy_stoplist cgi-bin ?" if @version.to_f < 3.5 %>
 
 <% node['squid']['logformats'].each do |name, format| %>
 logformat <%= name %> <%= format %>


### PR DESCRIPTION
### Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


This change allows squid to be used as a transparent proxy using SSL
Bump in order to allow connections to a whitelist of locations.

http://wiki.squid-cache.org/ConfigExamples/Intercept/SslBumpExplicit
http://wiki.squid-cache.org/Features/SslPeekAndSplice